### PR TITLE
Fix for gmcquillan/django-brake#10

### DIFF
--- a/brake/decorators.py
+++ b/brake/decorators.py
@@ -81,7 +81,7 @@ def ratelimit(
                     (increment is None or (callable(increment) and increment(
                         request, response
                     ))):
-                _backend.count(func_name, request, ip, field, period)
+                    _backend.count(func_name, request, ip, field, period)
 
             return response
 

--- a/brake/decorators.py
+++ b/brake/decorators.py
@@ -76,7 +76,8 @@ def ratelimit(
                 # the actual function to get the result.
                 response = fn(request, *args, **kw)
 
-            if _method_match(request, method) and \
+            if not isinstance(response, HttpResponseTooManyRequests):
+                if _method_match(request, method) and \
                     (increment is None or (callable(increment) and increment(
                         request, response
                     ))):


### PR DESCRIPTION
This fixes issue at gmcquillan/django-brake#10. 

By testing request to ensure it is not an ```HttpResponseTooManyRequests``` object, the increment lambda doesn't choke on the error.