### PR TITLE
Improve rate-limiting windowing for the default cache backend.

### DIFF
--- a/brake/backends/cachebe.py
+++ b/brake/backends/cachebe.py
@@ -78,8 +78,8 @@ class CacheBackend(BaseBackend):
             if ':ip:' in counter:
                 ratelimited_by = 'ip'
 
-            current_count = counters["counter"]
-            if isinstance(counters[counter], tuple):
+            current_count = counters[counter]
+            if isinstance(current_count, tuple):
                 current_count = current_count[0]
 
             if current_count > count:


### PR DESCRIPTION
This is related to #20. Instead of renewing the rate limit every request, this PR resets the limits every `period` seconds.

This means that:

* Originally, if you set a limit of 10/minute and performed one request every 30 seconds, you would get rate-limited after 11 requests, since the counter would never reset.
* After this change, the counter resets every minute, so performing one request every 30 seconds will never get you rate-limited.

There is an issue in this PR that will require the cache to be cleared when upgrading, due to the changing data format in the cache key. I can check the data type and upgrade backwards-compatibly, if needed.