### PR TITLE
Make sure the timeout is an integer, as floats cause problems.

### DIFF
--- a/brake/backends/cachebe.py
+++ b/brake/backends/cachebe.py
@@ -62,7 +62,7 @@ class CacheBackend(BaseBackend):
                 count = value
                 expiration = time.time() + period
             count += 1
-            cache.set(key, (count, expiration), timeout=(expiration - time.time()))
+            cache.set(key, (count, expiration), timeout=int(expiration - time.time()))
 
     def limit(self, func_name, request,
             ip=True, field=None, count=5, period=None):


### PR DESCRIPTION
Previously, `timeout` could be a float, which, combined with django-redis, would effectively never expire a key if it was between 0 and 1. Ensuring that the timeout is an integer is the right thing to do in any case, as cache.set expects an integer, but it will also fix this problem.

If you could make a bugfix release with this, I would be grateful, as it is impacting our production right now.