### PR TITLE
Unit tests for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
     - "2.7"
+    - "3.6"
 env:
     - DJANGO_VERSION=1.3.7
     - DJANGO_VERSION=1.4.20
@@ -14,3 +15,9 @@ install:
     - python setup.py develop
 script:
     - bash test.sh
+matrix:
+  exclude:
+    - python: "3.6"
+      env: "DJANGO_VERSION=1.3.7"
+    - python: "3.6"
+      env: "1.4.20"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
     - DJANGO_VERSION=1.9.9
     - DJANGO_VERSION=1.10.1
 install:
-    - python setup.py develop
     - pip install django==$DJANGO_VERSION
+    - python setup.py develop
 script:
     - bash test.sh
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
     - "2.7"
-    - "3.6"
 env:
     - DJANGO_VERSION=1.3.7
     - DJANGO_VERSION=1.4.20
@@ -13,11 +12,34 @@ env:
     - DJANGO_VERSION=1.10.1
 install:
     - python setup.py develop
+    - pip install django==$DJANGO_VERSION
 script:
     - bash test.sh
 matrix:
-  exclude:
+  include:
+    - python: "3.3"
+      env: DJANGO_VERSION=1.6.11
+    - python: "3.3"
+      env: DJANGO_VERSION=1.7.8
+    - python: "3.3"
+      env: DJANGO_VERSION=1.8.2
+    - python: "3.4"
+      env: DJANGO_VERSION=1.7.8
+    - python: "3.4"
+      env: DJANGO_VERSION=1.8.2
+    - python: "3.4"
+      env: DJANGO_VERSION=1.9.9
+    - python: "3.4"
+      env: DJANGO_VERSION=1.10.1
+    - python: "3.4"
+      env: DJANGO_VERSION=1.11
+    - python: "3.5"
+      env: DJANGO_VERSION=1.8.2
+    - python: "3.5"
+      env: DJANGO_VERSION=1.9.9
+    - python: "3.5"
+      env: DJANGO_VERSION=1.10.1
+    - python: "3.5"
+      env: DJANGO_VERSION=1.11.0
     - python: "3.6"
-      env: "DJANGO_VERSION=1.3.7"
-    - python: "3.6"
-      env: "1.4.20"
+      env: DJANGO_VERSION=1.11.0

--- a/brake/tests/tests.py
+++ b/brake/tests/tests.py
@@ -306,5 +306,5 @@ class TestRateLimiting(RateLimitTestCase):
         # These are the cache keys that are specified by the decorator
         # for this view.
         for key in self.FAKE_LOGIN_CACHE_KEYS:
-            self.assertTrue(cache.get(key) > 1)
+            self.assertTrue(cache.get(key)[0] > 1)
 


### PR DESCRIPTION
I fixed a unit test that was broken on Python 3 and enabled Travis testing for all versions of Django >=1.6. The versions of Python 3.x are restricted based on the Python 3 versions that each Django release supports.