### PR TITLE
Closes #40: Django 2.1 and newer support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,5 @@ matrix:
       env: DJANGO_VERSION=1.11.0
     - python: "3.6"
       env: DJANGO_VERSION=1.11.0
+    - python: "3.5"
+      env: DJANGO_VERSION=2.2.3

--- a/brake/decorators.py
+++ b/brake/decorators.py
@@ -61,8 +61,10 @@ def ratelimit(
 
             if use_request_path:
                 func_name = request.path
-            else:
+            elif hasattr(fn, '__name__'):
                 func_name = fn.__name__
+            else:
+                func_name = fn.func.__name__
             response = None
             if _method_match(request, method):
                 limits = _backend.limit(


### PR DESCRIPTION
Hello, this is a simple fix for `django-brake` to support recent Django versions.